### PR TITLE
Fix : postId이동시 댓글이 유지되는 에러 수정

### DIFF
--- a/src/hooks/useComment.ts
+++ b/src/hooks/useComment.ts
@@ -27,6 +27,8 @@ export const useCommentActions = (postId: number) => {
     setModalOpen(false);
     setSelectedReplyId(null);
   };
+
+  // 댓글, 대댓글 불러오기
   const loadComments = async () => {
     try {
       const data: CommentType[] = await fetchComments(postId);
@@ -39,6 +41,7 @@ export const useCommentActions = (postId: number) => {
     }
   };
 
+  // 댓글 작성
   const handleCommentSubmit = async (content: string) => {
     if (!accessToken) {
       toast({
@@ -59,6 +62,7 @@ export const useCommentActions = (postId: number) => {
     }
   };
 
+  // 대댓글 작성
   const handleReplySubmit = async (commentId: number, content: string) => {
     if (!accessToken) {
       toast({
@@ -78,6 +82,7 @@ export const useCommentActions = (postId: number) => {
     }
   };
 
+  // 댓글 삭제
   const handleDeleteComment = async () => {
     if (selectedCommentId !== null) {
       try {
@@ -90,6 +95,7 @@ export const useCommentActions = (postId: number) => {
     }
   };
 
+  // 대댓글 삭제
   const handleDeleteReply = async (commentId: number, replyId: number) => {
     try {
       await deleteCommentReplyById(replyId);
@@ -111,10 +117,12 @@ export const useCommentActions = (postId: number) => {
     }
   };
 
+  // 대댓글 입력창 토글
   const toggleReplyInput = (commentId: number) => {
     setReplyVisibility((prev) => ({ ...prev, [commentId]: !prev[commentId] }));
   };
 
+  // 대댓글 옵션 토글
   const toggleOptions = (commentId: number) => {
     setShowOptions((prev) => ({ ...prev, [commentId]: !prev[commentId] }));
   };

--- a/src/pages/Post/DetailPost/index.tsx
+++ b/src/pages/Post/DetailPost/index.tsx
@@ -23,7 +23,7 @@ const DetailPostPage = () => {
   const openModal = () => setModalOpen(true);
   const closeModal = () => setModalOpen(false);
   // zustand로 data와 postId 전역관리
-  const { post, setPost, postId, setPostId } = usePostStore();
+  const { post, setPost, postId, setPostId, clearPost } = usePostStore();
 
   // React Query를 사용하여 데이터 가져오기 및 캐싱
   // main.tsx에서 loading을 하므로 굳이 여기서 할 필요는 없다.
@@ -51,21 +51,21 @@ const DetailPostPage = () => {
     }
   };
 
-  // postId가 변경되면 postId를 업데이트
   useEffect(() => {
     if (id) {
       const postId = Number(id);
       setPostId(postId);
     }
-  }, [id, setPostId]);
 
-  // data가 변경되면 post를 업데이트
-  useEffect(() => {
     if (data) {
       setPost(data);
     }
-  }, [data, setPost]);
 
+    // 페이지 언마운트 시 clearPost 호출
+    return () => {
+      clearPost();
+    };
+  }, [id, postId, data, setPostId, setPost, clearPost]);
   return (
     <Layout>
       <>
@@ -104,12 +104,14 @@ const DetailPostPage = () => {
             <p className="mb-4">{post.content}</p>
             <div className="flex flex-row mb-4">
               <span className="font-semibold text-[#ee3918] mr-4">첨부된 파일:</span>
-              <p className="font-bold">{post.file_attachment.split('/').pop()}</p>
+              <p className="font-bold">
+                {post.file_attchment === '{}' ? post.file_attachment.split('/').pop() : null}
+              </p>
             </div>
             <div className="mb-4">
-              {post.hashtags?.map((tag: string, index: number) => (
+              {post.hashtags?.map((tag: string, _: number) => (
                 <span
-                  key={index}
+                  key={tag}
                   className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
                 >
                   #{tag}

--- a/src/store/postStore.ts
+++ b/src/store/postStore.ts
@@ -6,6 +6,7 @@ const usePostStore = create<PostStoreDTO>((set) => ({
   postId: null,
   setPost: (post) => set({ post }),
   setPostId: (id) => set({ postId: id }),
+  clearPost: () => set({ post: null, postId: null }),
 }));
 
 export default usePostStore;

--- a/src/type/Store/postStore.ts
+++ b/src/type/Store/postStore.ts
@@ -3,4 +3,5 @@ export type PostStoreDTO = {
   postId: number | null;
   setPost: (post: any) => void;
   setPostId: (id: number) => void;
+  clearPost: () => void;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#6 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- zustand에서 페이지 이동시 postId, post가 리셋되도록 설정함

